### PR TITLE
Add no_std support and SeekWrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.bk
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,18 @@ authors = [
 ]
 description = "Reading and writing at an offset"
 keywords = ["read", "offset", "pread", "pwrite", "endian"]
-categories = ["filesystem", "os"]
+categories = ["filesystem", "os", "no-std"]
 license = "MIT"
 repository = "https://github.com/surban/positioned-io2"
 readme = "README.md"
 
 [features]
-default = ["byteorder"]
+default = ["byteorder", "std"]
+std = ["acid_io/std"]
 
 [dependencies]
 byteorder = { version = "1.4", optional = true }
+acid_io = { version = "0.1.0", default-features = false, features = ["alloc"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,10 +1,9 @@
-use std::cmp::min;
-use std::io;
+use core::cmp::min;
 
 use super::{ReadAt, Size, WriteAt};
 
 impl<'a> ReadAt for &'a [u8] {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         if pos >= self.len() as u64 {
             return Ok(0);
         }
@@ -16,14 +15,14 @@ impl<'a> ReadAt for &'a [u8] {
 }
 
 impl<'a> ReadAt for &'a mut [u8] {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         let immutable: &[u8] = self;
         immutable.read_at(pos, buf)
     }
 }
 
 impl<'a> WriteAt for &'a mut [u8] {
-    fn write_at(&mut self, pos: u64, buf: &[u8]) -> io::Result<usize> {
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize> {
         if pos >= self.len() as u64 {
             return Ok(0);
         }
@@ -33,19 +32,19 @@ impl<'a> WriteAt for &'a mut [u8] {
         Ok(bytes)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         Ok(())
     }
 }
 
 impl<'a> Size for &'a [u8] {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         Ok(Some(self.len() as u64))
     }
 }
 
 impl<'a> Size for &'a mut [u8] {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         Ok(Some(self.len() as u64))
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::io::{Read, Seek, SeekFrom, Write};
+use acid_io::{Read, Seek, SeekFrom, Write};
 
 use super::{ReadAt, Size, WriteAt};
 
@@ -104,22 +103,22 @@ impl<I> Cursor<I> {
 }
 
 impl<I> Seek for Cursor<I> {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+    fn seek(&mut self, pos: SeekFrom) -> acid_io::Result<u64> {
         match pos {
             SeekFrom::Start(p) => self.pos = p,
             SeekFrom::Current(p) => {
                 let pos = self.pos as i64 + p;
                 if pos < 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
+                    return Err(acid_io::Error::new(
+                        acid_io::ErrorKind::InvalidInput,
                         "seek to a negative position",
                     ));
                 }
                 self.pos = pos as u64;
             }
             SeekFrom::End(_) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
+                return Err(acid_io::Error::new(
+                    acid_io::ErrorKind::InvalidInput,
                     "seek from unknown end",
                 ))
             }
@@ -129,7 +128,7 @@ impl<I> Seek for Cursor<I> {
 }
 
 impl<I: ReadAt> Read for Cursor<I> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> acid_io::Result<usize> {
         let bytes = self.get_ref().read_at(self.pos, buf)?;
         self.pos += bytes as u64;
         Ok(bytes)
@@ -137,7 +136,7 @@ impl<I: ReadAt> Read for Cursor<I> {
 }
 
 impl<I: WriteAt> Write for Cursor<I> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> acid_io::Result<usize> {
         let pos = self.pos;
         let bytes = self.get_mut().write_at(pos, buf)?;
         self.pos += bytes as u64;
@@ -145,7 +144,7 @@ impl<I: WriteAt> Write for Cursor<I> {
     }
 
     #[inline]
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         WriteAt::flush(self.get_mut())
     }
 }
@@ -232,34 +231,34 @@ impl<I: Size> SizeCursor<I> {
 
 impl<I: Size + ReadAt> Read for SizeCursor<I> {
     #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> acid_io::Result<usize> {
         self.cursor.read(buf)
     }
 }
 
 impl<I: Size + WriteAt> Write for SizeCursor<I> {
     #[inline]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> acid_io::Result<usize> {
         self.cursor.write(buf)
     }
 
     #[inline]
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         self.cursor.flush()
     }
 }
 
 // We know how to seek from the end for SizeCursor.
 impl<I: Size> Seek for SizeCursor<I> {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+    fn seek(&mut self, pos: SeekFrom) -> acid_io::Result<u64> {
         let pos = match pos {
             SeekFrom::Start(p) => p as i64,
             SeekFrom::Current(p) => self.cursor.pos as i64 + p,
             SeekFrom::End(p) => match self.get_ref().size() {
                 Err(e) => return Err(e),
                 Ok(None) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
+                    return Err(acid_io::Error::new(
+                        acid_io::ErrorKind::InvalidData,
                         "seek from unknown end",
                     ))
                 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -17,6 +17,8 @@ use super::{ReadAt, Size, WriteAt};
 /// # Examples
 ///
 /// ```no_run
+/// # #[cfg(not(feature = "std"))] fn main() {}
+/// # #[cfg(feature = "std")] fn main() {
 /// # use std::io::{self, Result, Read};
 /// # use std::fs::File;
 /// use positioned_io2::{ReadAt, Cursor};
@@ -46,6 +48,7 @@ use super::{ReadAt, Size, WriteAt};
 /// let mut output = File::create("segment.out")?;
 /// io::copy(&mut input, &mut output)?;
 /// # Ok(())
+/// # }
 /// # }
 /// ```
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! This crate allows you to specify an offset for reads and writes,
 //! without changing the current position in a file. This is similar to
 //! [`pread()` and `pwrite()`][pread] in C.
@@ -124,6 +126,9 @@
 extern crate byteorder;
 #[cfg(unix)]
 extern crate libc;
+extern crate acid_io;
+extern crate alloc;
+extern crate core;
 
 mod cursor;
 pub use cursor::{Cursor, SizeCursor};
@@ -135,9 +140,6 @@ pub use slice::Slice;
 mod byteio;
 #[cfg(feature = "byteorder")]
 pub use byteio::{ByteIo, ReadBytesAtExt, WriteBytesAtExt};
-
-use std::fs::File;
-use std::io;
 
 /// Trait for reading bytes at an offset.
 ///
@@ -180,7 +182,7 @@ pub trait ReadAt {
     ///
     /// See [`Read::read()`](https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read)
     /// for details.
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize>;
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize>;
 
     /// Reads the exact number of bytes required to fill `buf` from an offset.
     ///
@@ -188,7 +190,7 @@ pub trait ReadAt {
     ///
     /// See [`Read::read_exact()`](https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact)
     /// for details.
-    fn read_exact_at(&self, mut pos: u64, mut buf: &mut [u8]) -> io::Result<()> {
+    fn read_exact_at(&self, mut pos: u64, mut buf: &mut [u8]) -> acid_io::Result<()> {
         while !buf.is_empty() {
             match self.read_at(pos, buf) {
                 Ok(0) => break,
@@ -197,13 +199,13 @@ pub trait ReadAt {
                     buf = &mut tmp[n..];
                     pos += n as u64;
                 }
-                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(ref e) if e.kind() == acid_io::ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }
         }
         if !buf.is_empty() {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
+            Err(acid_io::Error::new(
+                acid_io::ErrorKind::UnexpectedEof,
                 "failed to fill whole buffer",
             ))
         } else {
@@ -249,7 +251,7 @@ pub trait WriteAt {
     ///
     /// See [`Write::write()`](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write)
     /// for details.
-    fn write_at(&mut self, pos: u64, buf: &[u8]) -> io::Result<usize>;
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize>;
 
     /// Writes a complete buffer at an offset.
     ///
@@ -257,12 +259,12 @@ pub trait WriteAt {
     ///
     /// See [`Write::write_all()`](https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all)
     /// for details.
-    fn write_all_at(&mut self, mut pos: u64, mut buf: &[u8]) -> io::Result<()> {
+    fn write_all_at(&mut self, mut pos: u64, mut buf: &[u8]) -> acid_io::Result<()> {
         while !buf.is_empty() {
             match self.write_at(pos, buf) {
                 Ok(0) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::WriteZero,
+                    return Err(acid_io::Error::new(
+                        acid_io::ErrorKind::WriteZero,
                         "failed to write whole buffer",
                     ))
                 }
@@ -270,7 +272,7 @@ pub trait WriteAt {
                     buf = &buf[n..];
                     pos += n as u64;
                 }
-                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(ref e) if e.kind() == acid_io::ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }
         }
@@ -289,7 +291,7 @@ pub trait WriteAt {
     /// Use
     /// [`File::sync_data()`](https://doc.rust-lang.org/std/fs/struct.File.html#method.sync_data)
     /// instead.
-    fn flush(&mut self) -> io::Result<()>;
+    fn flush(&mut self) -> acid_io::Result<()>;
 }
 
 /// Trait to get the size in bytes of an I/O object.
@@ -328,11 +330,12 @@ pub trait Size {
     ///
     /// This function may return `Ok(None)` if the size is unknown, for example
     /// for pipes.
-    fn size(&self) -> io::Result<Option<u64>>;
+    fn size(&self) -> acid_io::Result<Option<u64>>;
 }
 
-impl Size for File {
-    fn size(&self) -> io::Result<Option<u64>> {
+#[cfg(feature = "std")]
+impl Size for std::fs::File {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         let md = self.metadata()?;
         if md.is_file() {
             Ok(Some(md.len()))
@@ -343,15 +346,17 @@ impl Size for File {
 }
 
 // Implementation for Unix files.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "std"))]
 mod unix;
 
 // Implementation for Windows files.
-#[cfg(windows)]
+#[cfg(all(windows, feature = "std"))]
 mod windows;
 
 // RandomAccess file wrapper.
+#[cfg(feature = "std")]
 mod raf;
+#[cfg(feature = "std")]
 pub use raf::RandomAccessFile;
 
 // Implementation for arrays, vectors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,11 @@
 //! Read the fifth 512-byte sector of a file:
 //!
 //! ```
+//! # #[cfg(not(feature = "std"))] fn main() {}
+//! # #[cfg(feature = "std")] fn main() {
 //! # use std::error::Error;
 //! #
-//! # fn try_main() -> Result<(), Box<Error>> {
+//! # fn try_main() -> Result<(), Box<dyn Error>> {
 //! use std::fs::File;
 //! use positioned_io2::ReadAt;
 //!
@@ -32,8 +34,7 @@
 //! #     Ok(())
 //! # }
 //! #
-//! # fn main() {
-//! #     try_main().unwrap();
+//! # try_main().unwrap();
 //! # }
 //! ```
 //!
@@ -128,6 +129,7 @@ extern crate byteorder;
 extern crate libc;
 extern crate acid_io;
 extern crate alloc;
+#[cfg(feature = "std")]
 extern crate core;
 
 mod cursor;
@@ -153,9 +155,11 @@ pub use byteio::{ByteIo, ReadBytesAtExt, WriteBytesAtExt};
 /// Read the fifth 512-byte sector of a file:
 ///
 /// ```
+/// # #[cfg(not(feature = "std"))] fn main() {}
+/// # #[cfg(feature = "std")] fn main() {
 /// # use std::error::Error;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
 /// use std::fs::File;
 /// use positioned_io2::ReadAt;
 ///
@@ -169,8 +173,7 @@ pub use byteio::{ByteIo, ReadBytesAtExt, WriteBytesAtExt};
 /// #     Ok(())
 /// # }
 /// #
-/// # fn main() {
-/// #     try_main().unwrap();
+/// # try_main().unwrap();
 /// # }
 /// ```
 pub trait ReadAt {
@@ -225,9 +228,11 @@ pub trait ReadAt {
 /// # Examples
 ///
 /// ```no_run
+/// # #[cfg(not(feature = "std"))] fn main() {}
+/// # #[cfg(feature = "std")] fn main() {
 /// # use std::error::Error;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
 /// use std::fs::OpenOptions;
 /// use positioned_io2::WriteAt;
 ///
@@ -238,8 +243,7 @@ pub trait ReadAt {
 /// #     Ok(())
 /// # }
 /// #
-/// # fn main() {
-/// #     try_main().unwrap();
+/// # try_main().unwrap();
 /// # }
 /// ```
 pub trait WriteAt {
@@ -304,9 +308,11 @@ pub trait WriteAt {
 /// # Examples
 ///
 /// ```no_run
+/// # #[cfg(not(feature = "std"))] fn main() {}
+/// # #[cfg(feature = "std")] fn main() {
 /// # use std::error::Error;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
 /// use std::fs::File;
 /// use positioned_io2::Size;
 ///
@@ -321,8 +327,7 @@ pub trait WriteAt {
 /// #     Ok(())
 /// # }
 /// #
-/// # fn main() {
-/// #    try_main().unwrap();
+/// # try_main().unwrap();
 /// # }
 /// ```
 pub trait Size {
@@ -366,6 +371,7 @@ mod vec;
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
     use super::*;
 
     struct _AssertObjectSafe1(Box<dyn ReadAt>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,9 @@ mod byteio;
 #[cfg(feature = "byteorder")]
 pub use byteio::{ByteIo, ReadBytesAtExt, WriteBytesAtExt};
 
+mod wrapper;
+pub use wrapper::SeekWrapper;
+
 /// Trait for reading bytes at an offset.
 ///
 /// Implementations should be able to read bytes without changing any sort of

--- a/src/raf.rs
+++ b/src/raf.rs
@@ -26,7 +26,7 @@ use super::{ReadAt, WriteAt};
 /// ```
 /// # use std::error::Error;
 /// #
-/// # fn try_main() -> Result<(), Box<Error>> {
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
 /// use positioned_io2::{RandomAccessFile, ReadAt};
 ///
 /// // open a file (note: binding does not need to be mut)

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -1,59 +1,58 @@
-use std::cell::RefCell;
-use std::io;
+use core::cell::RefCell;
 
 use super::{ReadAt, Size, WriteAt};
 
 impl<'a, R: ReadAt + ?Sized> ReadAt for &'a R {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         R::read_at(self, pos, buf)
     }
 }
 
 impl<'a, R: ReadAt + ?Sized> ReadAt for &'a mut R {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         R::read_at(self, pos, buf)
     }
 }
 
 impl<'a, W: WriteAt + ?Sized> WriteAt for &'a mut W {
-    fn write_at(&mut self, pos: u64, buf: &[u8]) -> io::Result<usize> {
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize> {
         W::write_at(self, pos, buf)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         W::flush(self)
     }
 }
 
 impl<'a, S: Size + ?Sized> Size for &'a S {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         S::size(self)
     }
 }
 impl<'a, S: Size + ?Sized> Size for &'a mut S {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         S::size(self)
     }
 }
 
 impl<'a, R: ReadAt> ReadAt for &'a RefCell<R> {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         self.borrow().read_at(pos, buf)
     }
 }
 
 impl<'a, W: WriteAt> WriteAt for &'a RefCell<W> {
-    fn write_at(&mut self, pos: u64, buf: &[u8]) -> io::Result<usize> {
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize> {
         self.borrow_mut().write_at(pos, buf)
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         self.borrow_mut().flush()
     }
 }
 
 impl<'a, S: Size> Size for &'a RefCell<S> {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         self.borrow().size()
     }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,5 +1,4 @@
-use std::cmp::min;
-use std::io;
+use core::cmp::min;
 
 use super::{ReadAt, Size, WriteAt};
 
@@ -79,11 +78,11 @@ impl<I: Size> Slice<I> {
     ///
     /// Note that you can create a larger slice by passing a larger size to
     /// `new()`, but it won't do you any good for reading.
-    pub fn new_to_end(io: I, offset: u64) -> io::Result<Self> {
+    pub fn new_to_end(io: I, offset: u64) -> acid_io::Result<Self> {
         match io.size() {
             Ok(Some(size)) => Ok(Self::new(io, offset, Some(size - offset))),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
+            _ => Err(acid_io::Error::new(
+                acid_io::ErrorKind::InvalidData,
                 "unknown base size",
             )),
         }
@@ -91,25 +90,25 @@ impl<I: Size> Slice<I> {
 }
 
 impl<I: ReadAt> ReadAt for Slice<I> {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         let bytes = self.avail(pos, buf.len());
         self.io.read_at(pos + self.offset, &mut buf[..bytes])
     }
 }
 
 impl<I: WriteAt> WriteAt for Slice<I> {
-    fn write_at(&mut self, pos: u64, buf: &[u8]) -> io::Result<usize> {
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize> {
         let bytes = self.avail(pos, buf.len());
         self.io.write_at(pos + self.offset, &buf[..bytes])
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         self.io.flush()
     }
 }
 
 impl<I> Size for Slice<I> {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         Ok(self.size)
     }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -11,7 +11,7 @@ use super::{ReadAt, Size, WriteAt};
 /// Some slices have size restrictions:
 ///
 /// ```rust
-/// # use std::io;
+/// # extern crate acid_io as io;
 /// use positioned_io2::{ReadAt, Slice};
 ///
 /// # fn foo() -> io::Result<()> {
@@ -30,7 +30,7 @@ use super::{ReadAt, Size, WriteAt};
 /// Some slices do not:
 ///
 /// ```rust
-/// # use std::io;
+/// # extern crate acid_io as io;
 /// use positioned_io2::{WriteAt, Slice};
 ///
 /// # fn foo() -> io::Result<()> {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,20 +1,20 @@
-use std::cmp::min;
-use std::io;
+use core::cmp::min;
+use alloc::vec::Vec;
 
 use super::{ReadAt, Size, WriteAt};
 
 impl ReadAt for Vec<u8> {
-    fn read_at(&self, pos: u64, buf: &mut [u8]) -> io::Result<usize> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
         self.as_slice().read_at(pos, buf)
     }
 }
 
 impl WriteAt for Vec<u8> {
-    fn write_at(&mut self, pos: u64, buf: &[u8]) -> io::Result<usize> {
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize> {
         // Ensure no overflow.
         if pos > (usize::max_value() as u64) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
+            return Err(acid_io::Error::new(
+                acid_io::ErrorKind::InvalidInput,
                 "vector size too big",
             ));
         }
@@ -39,13 +39,13 @@ impl WriteAt for Vec<u8> {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> acid_io::Result<()> {
         Ok(())
     }
 }
 
 impl Size for Vec<u8> {
-    fn size(&self) -> io::Result<Option<u64>> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
         Ok(Some(self.len() as u64))
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,105 @@
+use core::cell::RefCell;
+use acid_io::{Read, Seek, SeekFrom, Write};
+use ::{ReadAt, WriteAt};
+use Size;
+
+/// A wrapper that implements [`ReadAt`] and [`WriteAt`] for types
+/// implementing `Seek` and `Read` / `Write` respectively.
+///
+/// # Example
+///
+/// ```rust
+/// # extern crate acid_io;
+/// # use acid_io::{Cursor, Result};
+/// use positioned_io2::ReadAt;
+/// # fn try_main() -> Result<()> {
+/// use positioned_io2::{SeekWrapper, ReadAt, WriteAt};
+/// let mut vec = vec![0, 1, 2];
+/// let mut cursor = Cursor::new(vec);
+/// let mut wrapper = SeekWrapper::new(cursor);
+/// wrapper.write_at(2, &[3, 4, 5])?;
+/// let mut buf = [0; 3];
+/// wrapper.read_exact_at(1, &mut buf)?;
+/// assert_eq!(buf, [1, 3, 4]);
+/// # Ok(())
+/// # }
+/// # try_main().unwrap();
+/// ```
+#[derive(Debug)]
+pub struct SeekWrapper<T> {
+    inner: RefCell<SeekWrapperInner<T>>,
+}
+#[derive(Debug)]
+struct SeekWrapperInner<T> {
+    position: Option<u64>,
+    inner: T,
+}
+
+
+impl<T> SeekWrapper<T> {
+    /// Creates a new wrapper around the inner reader / writer.
+    pub const fn new(inner: T) -> SeekWrapper<T> {
+        SeekWrapper { inner: RefCell::new(SeekWrapperInner { position: None, inner }) }
+    }
+}
+
+impl<T: Read + Seek> ReadAt for SeekWrapper<T> {
+    fn read_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<usize> {
+        let mut inner = self.inner.borrow_mut();
+
+        if inner.position != Some(pos) {
+            inner.inner.seek(SeekFrom::Start(pos))?;
+        }
+        let read = inner.inner.read(buf)?;
+        inner.position = Some(pos + read as u64);
+        Ok(read)
+    }
+
+    fn read_exact_at(&self, pos: u64, buf: &mut [u8]) -> acid_io::Result<()> {
+        let mut inner = self.inner.borrow_mut();
+
+        if inner.position != Some(pos) {
+            inner.inner.seek(SeekFrom::Start(pos))?;
+        }
+        inner.inner.read_exact(buf)?;
+        inner.position = Some(pos + buf.len() as u64);
+        Ok(())
+    }
+}
+
+impl<T: Write + Seek> WriteAt for SeekWrapper<T> {
+    fn write_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<usize> {
+        let mut inner = self.inner.get_mut();
+
+        if inner.position != Some(pos) {
+            inner.inner.seek(SeekFrom::Start(pos))?;
+        }
+        let written = inner.inner.write(buf)?;
+        inner.position = Some(pos + written as u64);
+        Ok(written)
+    }
+
+    fn write_all_at(&mut self, pos: u64, buf: &[u8]) -> acid_io::Result<()> {
+        let mut inner = self.inner.get_mut();
+
+        if inner.position != Some(pos) {
+            inner.inner.seek(SeekFrom::Start(pos))?;
+        }
+        inner.inner.write_all(buf)?;
+        inner.position = Some(pos + buf.len() as u64);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> acid_io::Result<()> {
+        self.inner.get_mut().inner.flush()
+    }
+}
+
+impl<T: Seek> Size for SeekWrapper<T> {
+    fn size(&self) -> acid_io::Result<Option<u64>> {
+        let mut borrow = self.inner.borrow_mut();
+        let pos = borrow.inner.seek(SeekFrom::End(0))?;
+        borrow.position = Some(pos);
+        Ok(Some(pos))
+    }
+}

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,14 +1,19 @@
-#[macro_use]
+#[cfg_attr(feature = "std", macro_use)]
 extern crate quickcheck;
 extern crate positioned_io2;
 extern crate rand;
 extern crate tempfile;
+#[cfg(feature = "std")]
+extern crate acid_io;
 
+#[cfg(feature = "std")]
 use std::cmp::{max, min};
-use std::io::{Read, Seek, SeekFrom, Write};
+#[cfg(feature = "std")]
+use acid_io::{Read, Seek, SeekFrom, Write};
 
 use self::quickcheck::{Arbitrary, Gen};
 use self::rand::Rng;
+#[cfg(feature = "std")]
 use positioned_io2::{ReadAt, WriteAt};
 
 #[derive(Clone, Debug)]
@@ -34,11 +39,13 @@ impl Arbitrary for Op {
     }
 }
 
+#[cfg(feature = "std")]
 struct Model {
     vec: Vec<u8>,
     pos: usize,
 }
 
+#[cfg(feature = "std")]
 impl Model {
     fn new() -> Model {
         Model {
@@ -72,6 +79,7 @@ impl Model {
     }
 }
 
+#[cfg(feature = "std")]
 quickcheck! {
     fn file_matches_model(ops: Vec<Op>) -> bool {
         let mut file = tempfile::tempfile().unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,21 +1,29 @@
 use std::cell::{Cell, RefCell};
+#[cfg(feature = "std")]
 use std::fs::File;
-use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom};
+#[cfg(feature = "std")]
+use acid_io::{Error, ErrorKind, Read, Seek, SeekFrom};
+use acid_io::Result;
+#[cfg(feature = "std")]
 use std::str;
 
 #[cfg(feature = "byteorder")]
 extern crate byteorder;
 extern crate positioned_io2;
 extern crate tempfile;
+extern crate acid_io;
 #[cfg(feature = "byteorder")]
 use self::byteorder::LittleEndian;
 
-use positioned_io2::{Cursor, RandomAccessFile, ReadAt, Size, SizeCursor, Slice, WriteAt};
+use positioned_io2::{ReadAt, Size, Slice, WriteAt};
+#[cfg(feature = "std")]
+use positioned_io2::{RandomAccessFile, Cursor, SizeCursor};
 
 #[cfg(feature = "byteorder")]
 use positioned_io2::ByteIo;
 
 #[test]
+#[cfg(feature = "std")]
 fn test_read_at() {
     let file = File::open("tests/pi.txt").unwrap();
     let mut buf = [0; 4];
@@ -24,6 +32,7 @@ fn test_read_at() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_mixed_read() {
     let mut file = File::open("tests/pi.txt").unwrap();
     let mut buf = [0; 4];
@@ -41,6 +50,7 @@ struct ReadCustom<I: ReadAt, F: Fn() -> Result<usize>> {
     fail: Cell<bool>,
     onfail: F,
 }
+#[cfg(feature = "std")]
 impl<I: ReadAt, F: Fn() -> Result<usize>> ReadCustom<I, F> {
     fn new(i: I, f: F) -> Self {
         ReadCustom {
@@ -63,6 +73,7 @@ impl<I: ReadAt, F: Fn() -> Result<usize>> ReadAt for ReadCustom<I, F> {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_read_fails() {
     // Test interrupts.
     let file = File::open("tests/pi.txt").unwrap();
@@ -86,6 +97,7 @@ fn test_read_fails() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_size() {
     let file = File::open("tests/pi.txt").unwrap();
     let size = file.size().unwrap().unwrap();
@@ -93,6 +105,7 @@ fn test_size() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_cursor() {
     let file = File::open("tests/pi.txt").unwrap();
     let mut curs = Cursor::new_pos(file, 10);
@@ -107,6 +120,7 @@ fn test_cursor() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_size_cursor() {
     let file = File::open("Cargo.toml").unwrap();
     let mut curs = SizeCursor::new_pos(file, 10);
@@ -261,6 +275,7 @@ fn test_refcell() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn shared_refs() {
     let file = tempfile::tempfile().unwrap();
     // no mut


### PR DESCRIPTION
Add no_std support by using `acid_io` instead of `std::io` and gating `File*`-implementations on `cfg(feature = "std")`. The current published version of `acid_io` doesn't compile on no_std on Windows, but works if compiled with the `std`-feature.

Add `SeekWrapper` which implements `ReadAt` / `WriteAt` for `Read + Seek` / `Write + Seek`.